### PR TITLE
LLE-1224: Fix quickmenu header height

### DIFF
--- a/src/workflow.scss
+++ b/src/workflow.scss
@@ -1223,16 +1223,18 @@ $font-roboto: 'Roboto', sans-serif !important;
   -moz-box-shadow: 0px 0px 7px 0px rgba(204,204,204,0.5) !important;
   box-shadow: 0px 0px 7px 0px rgba(204,204,204,0.5) !important;
 }
+
 .workflow-extension-quickmenu-right-header{
-  height: 40px !important;
+  min-height: 40px !important;
   display: flex !important;
   align-items: center !important;
-  padding: 0 12px !important;
+  padding: 4px 12px !important;
   border-bottom: 1px solid #E3E6EA;
   font-weight: 400 !important;
   font-family: $font-sans;
-  font-size:15px !important;
+  font-size: 15px !important;
 }
+
 .workflow-extension-quickmenu-right-content{
   padding: 0px 12px !important;
 }


### PR DESCRIPTION
In order to adjust the quickmenu header height in cases we have longer texts:
- replaced `height` with `min-height`
- added a small top and bottom padding