### PR TITLE
LLE-1228: Fix bug - Institute text cut short on Google Scholar

### DIFF
--- a/src/workflow.scss
+++ b/src/workflow.scss
@@ -1616,3 +1616,7 @@ animation: workflow-pulse 1s linear infinite;
   display: inline-block !important;
   min-width: 825px;
 }
+
+.gs_or_ggsm a {
+  white-space: normal !important;
+}


### PR DESCRIPTION
Added white-space: normal for class gs_or_ggsm a in order to prevent cutting words in Google Scholar.
