### PR TITLE
LLE-1303: Add box-sizing to quickmenu header

### DIFF
--- a/src/workflow.scss
+++ b/src/workflow.scss
@@ -1228,6 +1228,7 @@ $font-roboto: 'Roboto', sans-serif !important;
   min-height: 40px !important;
   display: flex !important;
   align-items: center !important;
+  box-sizing: border-box !important;
   padding: 4px 12px !important;
   border-bottom: 1px solid #E3E6EA;
   font-weight: 400 !important;


### PR DESCRIPTION
Logo and header title boxes were not in line, because the header was missing the `box-sizing` property